### PR TITLE
Bump CFPropertyList requirement to ~2.3

### DIFF
--- a/CFPropertyList-rails.gemspec
+++ b/CFPropertyList-rails.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
 
   s.files       = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
 
-  s.add_runtime_dependency(%q<CFPropertyList>, ["~> 2.2.0"])
+  s.add_runtime_dependency(%q<CFPropertyList>, ["~> 2.3"])
   s.add_runtime_dependency(%q<railties>, [">= 3", "< 5"])
 end


### PR DESCRIPTION
Seems to work fine and fixes a dependency issue for me since another gem is requiring CFPropertyList ~2.3.